### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1
+
+# Add keys and sources lists
+RUN curl -sL https://deb.nodesource.com/setup_11.x | bash
+RUN curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | apt-key add -
+RUN echo "deb https://dl.yarnpkg.com/debian/ stable main" \
+    | tee /etc/apt/sources.list.d/yarn.list
+
+# Install node, 7zip, yarn, git, process tools
+RUN apt-get update && apt-get install -y nodejs p7zip-full yarn git procps
+
+# Clean up
+RUN apt-get autoremove -y \
+    && apt-get clean -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install fake
+RUN dotnet tool install fake-cli -g
+
+# Install Paket
+RUN dotnet tool install paket -g
+
+# add dotnet tools to path to pick up fake and paket installation
+ENV PATH="/root/.dotnet/tools:${PATH}"
+
+# Copy the source code to /app directory and
+WORKDIR /app
+COPY . /app
+
+# Install all .NET dependencies
+RUN paket restore
+
+ENTRYPOINT [ "fake", "build", "-t", "Run" ]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,22 @@ If this is your first foray into F#, check out my [F# resources](https://github.
 
 ## Getting up and running
 
-### 1. Install dependencies
+### Docker
+
+The bundled `Dockerfile` can be used to build and run the project without any
+prerequisites.
+
+```bash
+$ docker build --tag accelerated .
+[...]
+$ docker run -d -p 8080:8080 -p 8085:8085 accelerated
+```
+
+Point your browser to [localhost:8080](http://localhost:8080).
+
+### Locally
+
+#### 1. Install dependencies
 
 If you haven't already, install the following dotnet global tools:
 
@@ -30,7 +45,7 @@ dotnet install -g femto
 
 and install [yarn](https://classic.yarnpkg.com/en/docs/install)
 
-#### Pre-existing `fake`
+##### Pre-existing `fake`
 
 If running under [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) with Ubuntu 16.04/18.04, you might run into an issue with a pre-existing [`fake`](https://packages.ubuntu.com/bionic/fake) command in `/usr/sbin`. To check for this issue, run:
 
@@ -42,7 +57,7 @@ dotnet tool uninstall -g fake-cli
 dotnet tool install -g fake-cli
 ```
 
-### 2. Restore the project
+#### 2. Restore the project
 
 Then restore the project:
 
@@ -53,7 +68,7 @@ paket restore
 $ femto restore src/Client/Client.fsproj
 ```
 
-### 3. Build the project
+#### 3. Build the project
 
 1. through CLI: `fake build -t Run`
 2. from VS Code: run the `Watch Client` target (`ctrl-shift-B`).


### PR DESCRIPTION
Add Dockerfile and documentation on how to build and run the application
in a Docker instance. This makes it easy to use the application without
any prerequisites. It also enables running the application in Azure by
just running a container.